### PR TITLE
feat: 使用 AsyncTaskManager 管理数据保存任务

### DIFF
--- a/src/main/java/cn/drcomo/DrcomoVEX.java
+++ b/src/main/java/cn/drcomo/DrcomoVEX.java
@@ -16,6 +16,7 @@ import cn.drcomo.utils.ServerVersion;
 import cn.drcomo.corelib.hook.placeholder.PlaceholderAPIUtil;
 import cn.drcomo.corelib.util.DebugUtil;
 import cn.drcomo.corelib.config.YamlUtil;
+import cn.drcomo.corelib.async.AsyncTaskManager;
 
 
 public class DrcomoVEX extends JavaPlugin {
@@ -37,6 +38,7 @@ public class DrcomoVEX extends JavaPlugin {
     private DebugUtil logger;
     private YamlUtil yamlUtil;
     private PlaceholderAPIUtil placeholderUtil;
+    private AsyncTaskManager asyncTaskManager;
 
     /**
      * 插件启用时的初始化逻辑。
@@ -48,6 +50,7 @@ public class DrcomoVEX extends JavaPlugin {
         this.logger = new DebugUtil(this, DebugUtil.LogLevel.INFO);
         this.yamlUtil = new YamlUtil(this, logger);
         this.placeholderUtil = new PlaceholderAPIUtil(this, getName().toLowerCase());
+        this.asyncTaskManager = new AsyncTaskManager(this, logger);
 
         this.variablesManager = new VariablesManager(this);
         this.serverVariablesManager = new ServerVariablesManager(this);
@@ -83,6 +86,9 @@ public class DrcomoVEX extends JavaPlugin {
     public void onDisable(){
         this.configsManager.saveServerData();
         this.configsManager.savePlayerData();
+        if(asyncTaskManager != null){
+            asyncTaskManager.shutdown();
+        }
         logger.info(messagesManager.translate(messagesManager.getPrefix() + " &eHas been disabled! &fVersion: " + version, null));
     }
 
@@ -194,6 +200,15 @@ public class DrcomoVEX extends JavaPlugin {
      */
     public PlaceholderAPIUtil getPlaceholderUtil() {
         return placeholderUtil;
+    }
+
+    /**
+     * 获取异步任务管理器。
+     *
+     * @return {@link AsyncTaskManager} 实例
+     */
+    public AsyncTaskManager getAsyncTaskManager() {
+        return asyncTaskManager;
     }
 
     /**

--- a/src/main/java/cn/drcomo/config/MainConfigManager.java
+++ b/src/main/java/cn/drcomo/config/MainConfigManager.java
@@ -54,12 +54,13 @@ public class MainConfigManager {
                                 config.getString("messages.prefix"),
                                 plugin.getPlaceholderUtil()));
 
-		DataSaveTask dataSaveTask = plugin.getDataSaveTask();
-		if(dataSaveTask != null) {
-			dataSaveTask.end();
-		}
-		dataSaveTask = new DataSaveTask(plugin);
-		dataSaveTask.start(config.getInt("config.data_save_time"));
+                DataSaveTask dataSaveTask = plugin.getDataSaveTask();
+                if(dataSaveTask != null) {
+                        dataSaveTask.end();
+                }
+                dataSaveTask = new DataSaveTask(plugin, plugin.getAsyncTaskManager());
+                dataSaveTask.start(config.getInt("config.data_save_time"));
+                plugin.setDataSaveTask(dataSaveTask);
 
 		updateNotify = config.getBoolean("update_notify");
 		isMySQL = config.getBoolean("config.mysql_database.enabled");

--- a/src/main/java/cn/drcomo/tasks/DataSaveTask.java
+++ b/src/main/java/cn/drcomo/tasks/DataSaveTask.java
@@ -1,39 +1,56 @@
 package cn.drcomo.tasks;
 
-import org.bukkit.scheduler.BukkitRunnable;
 import cn.drcomo.DrcomoVEX;
+import cn.drcomo.corelib.async.AsyncTaskManager;
 
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 数据定时保存任务。
+ * <p>负责以固定频率异步保存服务器与玩家数据。</p>
+ */
 public class DataSaveTask {
 
-	private DrcomoVEX plugin;
-	private boolean end;
-	public DataSaveTask(DrcomoVEX plugin) {
-		this.plugin = plugin;
-		this.end = false;
-	}
-	
-	public void end() {
-		end = true;
-	}
-	
-	public void start(int minutes) {
-		long ticks = minutes*60*20;
-		
-		new BukkitRunnable() {
-			@Override
-			public void run() {
-				if(end) {
-					this.cancel();
-				}else {
-					execute();
-				}
-			}
-			
-		}.runTaskTimerAsynchronously(plugin, 0L, ticks);
-	}
-	
-	public void execute() {
-		plugin.getConfigsManager().saveServerData();
-		plugin.getConfigsManager().savePlayerData();
-	}
+    private final DrcomoVEX plugin;
+    private final AsyncTaskManager asyncTaskManager;
+    private ScheduledFuture<?> future;
+
+    /**
+     * 使用插件主类与异步任务管理器初始化任务。
+     *
+     * @param plugin           插件主类实例
+     * @param asyncTaskManager 异步任务管理器
+     */
+    public DataSaveTask(DrcomoVEX plugin, AsyncTaskManager asyncTaskManager) {
+        this.plugin = plugin;
+        this.asyncTaskManager = asyncTaskManager;
+    }
+
+    /**
+     * 结束当前定时任务。
+     */
+    public void end() {
+        if (future != null) {
+            future.cancel(false);
+        }
+    }
+
+    /**
+     * 启动定时保存任务。
+     *
+     * @param minutes 间隔分钟数
+     */
+    public void start(int minutes) {
+        future = asyncTaskManager.scheduleAtFixedRate(this::execute, 0L, minutes, TimeUnit.MINUTES);
+    }
+
+    /**
+     * 执行保存逻辑。
+     */
+    public void execute() {
+        plugin.getConfigsManager().saveServerData();
+        plugin.getConfigsManager().savePlayerData();
+    }
 }
+


### PR DESCRIPTION
## Summary
- 在 `DrcomoVEX` 中集成 `AsyncTaskManager`，在插件关闭时释放线程资源
- `DataSaveTask` 改为由 `AsyncTaskManager` 调度并支持取消
- `MainConfigManager` 根据新任务构造方式注入异步管理器

## Testing
- `mvn -q -e -ntp test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688cae92dd4883309ac877cf57e3e974