### PR TITLE
实现周期变量自动重置任务

### DIFF
--- a/src/main/java/cn/drcomo/DrcomoVEX.java
+++ b/src/main/java/cn/drcomo/DrcomoVEX.java
@@ -5,6 +5,7 @@ import cn.drcomo.managers.*;
 import cn.drcomo.listeners.PlayerListener;
 import cn.drcomo.api.ServerVariablesAPI;
 import cn.drcomo.tasks.DataSaveTask;
+import cn.drcomo.tasks.VariableCycleTask;
 import cn.drcomo.database.HikariConnection;
 import cn.drcomo.corelib.util.DebugUtil;
 import cn.drcomo.corelib.config.YamlUtil;
@@ -47,6 +48,7 @@ public class DrcomoVEX extends JavaPlugin {
     
     // 定时任务
     private DataSaveTask dataSaveTask;
+    private VariableCycleTask variableCycleTask;
     
     @Override
     public void onEnable() {
@@ -91,6 +93,9 @@ public class DrcomoVEX extends JavaPlugin {
         // 1. 停止定时任务
         if (dataSaveTask != null) {
             dataSaveTask.stop();
+        }
+        if (variableCycleTask != null) {
+            variableCycleTask.stop();
         }
         
         // 2. 保存所有数据
@@ -221,10 +226,15 @@ public class DrcomoVEX extends JavaPlugin {
      */
     private void startScheduledTasks() {
         dataSaveTask = new DataSaveTask(
-                this, logger, variablesManager, 
+                this, logger, variablesManager,
                 configsManager.getMainConfig()
         );
         dataSaveTask.start();
+
+        variableCycleTask = new VariableCycleTask(
+                this, logger, variablesManager, configsManager
+        );
+        variableCycleTask.start();
     }
     
     /**

--- a/src/main/java/cn/drcomo/managers/VariablesManager.java
+++ b/src/main/java/cn/drcomo/managers/VariablesManager.java
@@ -1014,6 +1014,23 @@ public class VariablesManager {
     public Set<String> getAllVariableKeys() {
         return new HashSet<>(variableRegistry.keySet());
     }
+
+    /**
+     * 清理指定变量的所有缓存
+     *
+     * @param key 变量键名
+     */
+    public void invalidateAllCaches(String key) {
+        try {
+            // 移除对应的值缓存
+            valueCache.keySet().removeIf(cacheKey -> cacheKey.endsWith(":" + key));
+            // 移除可能相关的表达式缓存
+            expressionCache.entrySet().removeIf(entry -> entry.getKey().contains(key));
+            logger.debug("已清理变量缓存: " + key);
+        } catch (Exception e) {
+            logger.error("清理变量缓存失败: " + key, e);
+        }
+    }
     
     /**
      * 保存所有数据

--- a/src/main/java/cn/drcomo/tasks/VariableCycleTask.java
+++ b/src/main/java/cn/drcomo/tasks/VariableCycleTask.java
@@ -1,0 +1,149 @@
+package cn.drcomo.tasks;
+
+import cn.drcomo.DrcomoVEX;
+import cn.drcomo.config.ConfigsManager;
+import cn.drcomo.config.DataConfigManager;
+import cn.drcomo.managers.VariablesManager;
+import cn.drcomo.model.structure.Variable;
+import cn.drcomo.corelib.util.DebugUtil;
+
+import java.time.*;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 周期变量检测任务
+ *
+ * 定期检查带有 cycle 配置的变量，按需重置其值。
+ *
+ * @author BaiMo
+ */
+public class VariableCycleTask {
+
+    private final DrcomoVEX plugin;
+    private final DebugUtil logger;
+    private final VariablesManager variablesManager;
+    private final ConfigsManager configsManager;
+    private ScheduledFuture<?> task;
+
+    public VariableCycleTask(
+            DrcomoVEX plugin,
+            DebugUtil logger,
+            VariablesManager variablesManager,
+            ConfigsManager configsManager
+    ) {
+        this.plugin = plugin;
+        this.logger = logger;
+        this.variablesManager = variablesManager;
+        this.configsManager = configsManager;
+    }
+
+    /**
+     * 启动周期检测任务
+     */
+    public void start() {
+        if (!configsManager.getMainConfig().getBoolean("cycle.enabled", true)) {
+            logger.info("周期重置功能已禁用");
+            return;
+        }
+
+        int interval = configsManager.getMainConfig().getInt("cycle.check-interval-minutes", 1);
+        task = plugin.getAsyncTaskManager().scheduleAtFixedRate(
+                this::checkCycles,
+                0,
+                interval,
+                TimeUnit.MINUTES
+        );
+        logger.info("已启动周期变量检测任务，间隔: " + interval + " 分钟");
+    }
+
+    /**
+     * 停止周期检测任务
+     */
+    public void stop() {
+        if (task != null && !task.isCancelled()) {
+            task.cancel(false);
+            logger.info("周期变量检测任务已停止");
+        }
+    }
+
+    /**
+     * 检查并重置变量
+     */
+    private void checkCycles() {
+        try {
+            String zoneId = configsManager.getMainConfig().getString("cycle.timezone", "Asia/Shanghai");
+            ZoneId zone = ZoneId.of(zoneId);
+            ZonedDateTime now = ZonedDateTime.now(zone);
+
+            checkAndReset("daily", now.truncatedTo(ChronoUnit.DAYS));
+            checkAndReset("weekly", now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).truncatedTo(ChronoUnit.DAYS));
+            checkAndReset("monthly", now.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS));
+            checkAndReset("yearly", now.withDayOfYear(1).truncatedTo(ChronoUnit.DAYS));
+        } catch (Exception e) {
+            logger.error("周期变量检测任务异常", e);
+        }
+    }
+
+    /**
+     * 检查某个周期并执行重置
+     */
+    private void checkAndReset(String cycleType, ZonedDateTime cycleStart) {
+        DataConfigManager dataConfig = configsManager.getDataConfigManager();
+        long lastReset;
+        synchronized (dataConfig) {
+            lastReset = dataConfig.getLong("cycle.last-" + cycleType + "-reset", 0L);
+        }
+
+        long startMillis = cycleStart.toInstant().toEpochMilli();
+        if (lastReset < startMillis) {
+            resetVariables(cycleType.toUpperCase());
+            synchronized (dataConfig) {
+                dataConfig.updateCycleResetTime(cycleType, startMillis);
+            }
+            logger.info("已完成 " + cycleType + " 周期变量重置");
+        }
+    }
+
+    /**
+     * 重置指定周期的所有变量
+     */
+    private void resetVariables(String cycle) {
+        Set<String> keys = variablesManager.getAllVariableKeys();
+        for (String key : keys) {
+            Variable variable = variablesManager.getVariableDefinition(key);
+            if (variable == null) {
+                continue;
+            }
+            String cfg = variable.getCycle();
+            if (cfg == null || cfg.trim().isEmpty()) {
+                continue;
+            }
+            if (cfg.contains(" ")) {
+                // TODO: 支持 Cron 表达式周期重置
+                continue;
+            }
+            if (cycle.equalsIgnoreCase(cfg)) {
+                try {
+                    if (variable.isGlobal()) {
+                        plugin.getDatabase().executeUpdateAsync(
+                                "DELETE FROM server_variables WHERE variable_key = ?",
+                                key
+                        ).join();
+                    } else {
+                        plugin.getDatabase().executeUpdateAsync(
+                                "DELETE FROM player_variables WHERE variable_key = ?",
+                                key
+                        ).join();
+                    }
+                    variablesManager.invalidateAllCaches(key);
+                    logger.debug("已重置变量: " + key);
+                } catch (Exception e) {
+                    logger.error("重置变量失败: " + key, e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `VariableCycleTask`，定时检查并重置周期性变量
- `VariablesManager` 新增缓存清理方法
- 主类启动与关闭周期检测任务

## Testing
- `mvn -q test` *(失败：网络不可达，无法解析依赖)*

------
https://chatgpt.com/codex/tasks/task_e_688f0bc1117483309dcfb87ac0990743