### PR TITLE
修复变量表命名并完善 SQLite 初始化

### DIFF
--- a/src/main/java/cn/drcomo/database/HikariConnection.java
+++ b/src/main/java/cn/drcomo/database/HikariConnection.java
@@ -33,7 +33,7 @@ public class HikariConnection {
     private HikariDataSource dataSource;
     private SQLiteDB sqliteDB;
     private String databaseType;
-    
+
     // SQL 语句
     private static final List<String> INIT_SCRIPTS = Arrays.asList(
         // 玩家变量表
@@ -41,25 +41,25 @@ public class HikariConnection {
         "    id INTEGER PRIMARY KEY AUTOINCREMENT," +
         "    player_uuid VARCHAR(36) NOT NULL," +
         "    variable_key VARCHAR(255) NOT NULL," +
-        "    variable_value TEXT," +
+        "    value TEXT," +
         "    created_at BIGINT NOT NULL," +
         "    updated_at BIGINT NOT NULL," +
         "    UNIQUE(player_uuid, variable_key)" +
         ")",
-        
-        // 全局变量表
-        "CREATE TABLE IF NOT EXISTS global_variables (" +
+
+        // 服务器变量表
+        "CREATE TABLE IF NOT EXISTS server_variables (" +
         "    id INTEGER PRIMARY KEY AUTOINCREMENT," +
         "    variable_key VARCHAR(255) NOT NULL UNIQUE," +
-        "    variable_value TEXT," +
+        "    value TEXT," +
         "    created_at BIGINT NOT NULL," +
         "    updated_at BIGINT NOT NULL" +
         ")",
-        
+
         // 索引优化
         "CREATE INDEX IF NOT EXISTS idx_player_variables_uuid ON player_variables(player_uuid)",
         "CREATE INDEX IF NOT EXISTS idx_player_variables_key ON player_variables(variable_key)",
-        "CREATE INDEX IF NOT EXISTS idx_global_variables_key ON global_variables(variable_key)"
+        "CREATE INDEX IF NOT EXISTS idx_server_variables_key ON server_variables(variable_key)"
     );
     
     public HikariConnection(DrcomoVEX plugin, DebugUtil logger, ConfigsManager configsManager) {
@@ -105,9 +105,11 @@ public class HikariConnection {
         
         // 使用 DrcomoCoreLib 的 SQLiteDB
         sqliteDB = new SQLiteDB(plugin, dbFile, INIT_SCRIPTS);
-        
+
         try {
             sqliteDB.connect();
+            // 手动执行初始化脚本，确保表结构完整
+            sqliteDB.initializeSchema();
             logger.info("SQLite 数据库连接成功: " + dbFile);
         } catch (Exception e) {
             logger.error("SQLite 数据库连接失败", e);


### PR DESCRIPTION
## 摘要
- 将全局变量表重命名为 server_variables 并统一使用 value 字段
- SQLite 连接后立即执行初始化脚本，确保表结构创建

## 测试
- `mvn -q -e -DskipTests package`（因网络问题下载依赖失败）
- `sqlite3 test.db ...` 查看表结构，player_variables 与 server_variables 均已按新字段创建


------
https://chatgpt.com/codex/tasks/task_e_688f0bbf23dc8330af28acb7e1b08534