### PR TITLE
feat: 使用 schema 脚本初始化数据库

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS player_variables (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    player_uuid VARCHAR(36) NOT NULL,
+    variable_key VARCHAR(255) NOT NULL,
+    value TEXT,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL,
+    UNIQUE(player_uuid, variable_key)
+);
+
+CREATE TABLE IF NOT EXISTS server_variables (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    variable_key VARCHAR(255) NOT NULL UNIQUE,
+    value TEXT,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_player_variables_uuid ON player_variables(player_uuid);
+CREATE INDEX IF NOT EXISTS idx_player_variables_key ON player_variables(variable_key);
+CREATE INDEX IF NOT EXISTS idx_server_variables_key ON server_variables(variable_key);


### PR DESCRIPTION
## Summary
- 新增 `schema.sql`，集中定义玩家与服务器变量表及索引
- `HikariConnection` 读取 `schema.sql` 初始化 SQLite，并兼容 MySQL 解析脚本

## Testing
- `mvn -q test` *(失败: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*
- `sqlite3 test.db '.tables'`

------
https://chatgpt.com/codex/tasks/task_e_688f11b56fcc8330a95026d6a79da3c4