### PR TITLE
改进消息服务加载并添加命令测试

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,24 @@
             <version>26.0.2</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>be.seeseemelk</groupId>
+            <artifactId>MockBukkit-v1.20</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -86,6 +104,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/cn/drcomo/DrcomoVEX.java
+++ b/src/main/java/cn/drcomo/DrcomoVEX.java
@@ -14,6 +14,7 @@ import cn.drcomo.corelib.message.MessageService;
 import cn.drcomo.corelib.hook.placeholder.PlaceholderAPIUtil;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.Bukkit;
+import java.io.File;
 
 /**
  * DrcomoVEX 变量扩展系统 主类
@@ -131,20 +132,30 @@ public class DrcomoVEX extends JavaPlugin {
         
         // 配置工具
         yamlUtil = new YamlUtil(this, logger);
-        
+
+        // 若 messages.yml 不存在则复制默认文件
+        File msgFile = new File(getDataFolder(), "messages.yml");
+        if (!msgFile.exists()) {
+            yamlUtil.copyYamlFile("messages.yml", "");
+            logger.info("未找到 messages.yml，已生成默认文件。");
+        } else {
+            logger.info("检测到 messages.yml，准备加载消息。");
+        }
+
         // 异步任务管理器
         asyncTaskManager = AsyncTaskManager.newBuilder(this, logger)
                 .poolSize(4)
                 .build();
-        
+
         // PlaceholderAPI工具
         placeholderUtil = new PlaceholderAPIUtil(this, "drcomovex");
-        
+
         // 消息服务
         messageService = new MessageService(
                 this, logger, yamlUtil, placeholderUtil,
                 "messages.yml", "messages."
         );
+        logger.info("消息服务已加载，使用配置文件 messages.yml。");
     }
     
     /**

--- a/src/test/java/cn/drcomo/MainCommandTest.java
+++ b/src/test/java/cn/drcomo/MainCommandTest.java
@@ -1,0 +1,93 @@
+package cn.drcomo;
+
+import cn.drcomo.managers.MessagesManager;
+import cn.drcomo.managers.VariablesManager;
+import cn.drcomo.model.VariableResult;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * 主指令单元测试
+ */
+public class MainCommandTest {
+
+    private ServerMock server;
+    private PlayerMock player;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        player = server.addPlayer("TestPlayer");
+        player.addAttachment(MockBukkit.createMockPlugin(), "drcomovex.command.set", true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testSetCommandFailureShowsOperationFailed() {
+        TestMessagesManager messagesManager = new TestMessagesManager();
+        TestVariablesManager variablesManager = new TestVariablesManager();
+
+        MainCommand command = new MainCommand(null, null, messagesManager, variablesManager, null, null);
+
+        command.onCommand(player, null, "vex", new String[]{"set", "test", "123"});
+
+        assertEquals("error.operation-failed", messagesManager.lastKey);
+        assertEquals("测试失败", messagesManager.lastPlaceholders.get("reason"));
+    }
+
+    /**
+     * 失败结果的变量管理器
+     */
+    private static class TestVariablesManager extends VariablesManager {
+        public TestVariablesManager() {
+            super(null, null, null, null, null, null);
+        }
+
+        @Override
+        public CompletableFuture<VariableResult> setVariable(OfflinePlayer player, String key, String value) {
+            return CompletableFuture.completedFuture(
+                    VariableResult.failure("测试失败", "SET", key, player.getName())
+            );
+        }
+    }
+
+    /**
+     * 记录消息的消息管理器
+     */
+    private static class TestMessagesManager extends MessagesManager {
+        public CommandSender lastSender;
+        public String lastKey;
+        public Map<String, String> lastPlaceholders;
+
+        public TestMessagesManager() {
+            super(null, null, null);
+        }
+
+        @Override
+        public void sendMessage(CommandSender sender, String messageKey, Map<String, String> placeholders) {
+            this.lastSender = sender;
+            this.lastKey = messageKey;
+            this.lastPlaceholders = placeholders;
+        }
+
+        @Override
+        public void sendMessage(CommandSender sender, String messageKey) {
+            sendMessage(sender, messageKey, null);
+        }
+    }
+}


### PR DESCRIPTION
## 摘要
- 在核心工具初始化阶段检查并自动生成 `messages.yml`，并输出消息服务加载情况
- 新增基于 MockBukkit 的 `/vex set` 失败消息单元测试

## 测试
- `mvn -q test` *(因网络不可达，依赖下载失败)*

------
https://chatgpt.com/codex/tasks/task_e_688f11ac38a483308b1d0de9b5904261