### PR TITLE
修复带下划线变量占位符的键解析

### DIFF
--- a/src/main/java/cn/drcomo/api/ServerVariablesAPI.java
+++ b/src/main/java/cn/drcomo/api/ServerVariablesAPI.java
@@ -172,9 +172,9 @@ public class ServerVariablesAPI {
             if (isBlank.apply(rawArgs)) {
                 result = "变量名不能为空";
             } else {
-                String variableKey;
+                String variableKey = rawArgs; // 直接使用完整变量键
                 try {
-                    variableKey = placeholderUtil.splitArgs(rawArgs)[0];
+                    placeholderUtil.splitArgs(rawArgs); // 如需额外参数可在此解析
                 } catch (Exception e) {
                     logger.error("占位符 drcomovex_var 参数解析失败，原始输入: " + rawArgs, e);
                     result = "错误";
@@ -226,9 +226,9 @@ public class ServerVariablesAPI {
             if (isBlank.apply(rawArgs)) {
                 result = "变量名不能为空";
             } else {
-                String variableKey;
+                String variableKey = rawArgs; // 直接使用完整变量键
                 try {
-                    variableKey = placeholderUtil.splitArgs(rawArgs)[0];
+                    placeholderUtil.splitArgs(rawArgs); // 如需额外参数可在此解析
                 } catch (Exception e) {
                     logger.error("占位符 drcomovex_server_var 参数解析失败，原始输入: " + rawArgs, e);
                     result = "错误";
@@ -268,9 +268,9 @@ public class ServerVariablesAPI {
             if (isBlank.apply(rawArgs)) {
                 result = "变量名不能为空";
             } else {
-                String variableKey;
+                String variableKey = rawArgs; // 直接使用完整变量键
                 try {
-                    variableKey = placeholderUtil.splitArgs(rawArgs)[0];
+                    placeholderUtil.splitArgs(rawArgs); // 如需额外参数可在此解析
                 } catch (Exception e) {
                     logger.error("占位符 drcomovex_player_var 参数解析失败，原始输入: " + rawArgs, e);
                     result = "错误";


### PR DESCRIPTION
## 总结
- 调整 `%drcomovex_var_%`、`%drcomovex_server_var_%`、`%drcomovex_player_var_%` 的变量键解析逻辑，直接使用原始参数以保留下划线，并保留 `splitArgs` 供额外参数解析。

## 测试
- `mvn -q -e -DskipTests package`（网络不可达，构建失败）
- 手动编译并运行 `TestPlaceholder`，验证 `%drcomovex_var_player_level%` 与 `%drcomovex_player_var_player_level%` 均返回正确数值

------
https://chatgpt.com/codex/tasks/task_e_688f65a4f7148330b2892cf3ef0115e0