### PR TITLE
规范占位符示例为方括号格式

### DIFF
--- a/src/main/java/cn/drcomo/api/ServerVariablesAPI.java
+++ b/src/main/java/cn/drcomo/api/ServerVariablesAPI.java
@@ -147,19 +147,19 @@ public class ServerVariablesAPI {
         // 通用参数非空验证函数
         java.util.function.Function<String, Boolean> isBlank = s -> s == null || s.trim().isEmpty();
 
-        // =============== %drcomovex_var_<key>% ===============
+        // =============== %drcomovex_[var]_[变量名]% ===============
         // 返回变量的默认值(initial)
         placeholderUtil.register("var", (player, rawArgs) ->
                 processPlaceholder(placeholderUtil, "drcomovex_var", player, rawArgs,
                         (pl, key) -> getDefaultInitial(key)));
 
-        // ========= %drcomovex_global_var_<key>% =========
+        // ========= %drcomovex_[global_var]_[变量名]% =========
         // 强制以全局身份获取变量值
         placeholderUtil.register("global_var", (player, rawArgs) ->
                 processPlaceholder(placeholderUtil, "drcomovex_global_var", player, rawArgs,
                         (pl, key) -> fetchGlobalVariable(key)));
 
-        // ========= %drcomovex_player_var_<key>% =========
+        // ========= %drcomovex_[player_var]_[变量名]% =========
         // 强制以玩家身份获取变量值
         placeholderUtil.register("player_var", (player, rawArgs) ->
                 processPlaceholder(placeholderUtil, "drcomovex_player_var", player, rawArgs,

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -112,9 +112,9 @@ messages:
   placeholders:
     examples:
       - "&7占位符示例:"
-      - "&e%drcomovex_var_变量名% &7- 获取变量值"
-      - "&e%drcomovex_player_var_变量名% &7- 获取玩家变量值"
-      - "&e%drcomovex_server_var_变量名% &7- 获取服务器变量值"
+      - "&e%drcomovex_[var]_[变量名]% &7- 获取变量值"
+      - "&e%drcomovex_[player_var]_[变量名]% &7- 获取玩家变量值"
+      - "&e%drcomovex_[global_var]_[变量名]% &7- 获取服务器变量值"
 
   # 特殊消息类型
   special:


### PR DESCRIPTION
## 摘要
- 更新占位符示例，统一采用 `%drcomovex_[类型]_[变量名]%` 格式
- 调整 API 注释中的占位符样例，保持与新格式一致

## 测试
- `mvn -q test`（网络不可达，依赖下载失败）

------
https://chatgpt.com/codex/tasks/task_e_689458427f808330a1a4c32236fd26dd