### PR TITLE
确保关闭前完成变量数据持久化

### DIFF
--- a/src/main/java/cn/drcomo/DrcomoVEX.java
+++ b/src/main/java/cn/drcomo/DrcomoVEX.java
@@ -96,12 +96,13 @@ public class DrcomoVEX extends JavaPlugin {
         
         // 2. 关闭高性能变量管理器（会自动持久化所有数据并关闭数据库）
         if (variablesManager != null) {
-            variablesManager.shutdown().thenRun(() -> {
+            try {
+                // 阻塞等待关闭流程完成，确保数据完全持久化
+                variablesManager.shutdown().join();
                 logger.info("变量管理器已安全关闭");
-            }).exceptionally(throwable -> {
-                logger.error("变量管理器关闭异常", throwable);
-                return null;
-            });
+            } catch (Exception e) {
+                logger.error("变量管理器关闭异常", e);
+            }
         } else {
             // 如果变量管理器为空，直接关闭数据库
             if (database != null) {

--- a/src/main/java/cn/drcomo/tasks/DataSaveTask.java
+++ b/src/main/java/cn/drcomo/tasks/DataSaveTask.java
@@ -80,8 +80,8 @@ public class DataSaveTask {
         try {
             long startTime = System.currentTimeMillis();
             
-            // 保存所有变量数据
-            variablesManager.saveAllData();
+            // 保存所有变量数据并等待完成，避免任务提前结束
+            variablesManager.saveAllData().join();
             
             long duration = System.currentTimeMillis() - startTime;
             logger.debug("数据保存完成，耗时: " + duration + "ms");


### PR DESCRIPTION
## 摘要
- 插件关闭时等待变量管理器完全关闭，确保数据持久化与数据库连接释放。
- 定时保存任务中阻塞等待数据保存完成，避免任务提前结束。

## 测试
- `mvn -q test` *(失败: 无法解析 maven 插件，Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68947ca1d8448330931cdb974e7b49c4