### PR TITLE
完善变量加减值校验并新增边界处理工具

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,14 @@
             <version>9.2.1</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- 测试依赖：JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
+++ b/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
@@ -10,6 +10,7 @@ import cn.drcomo.corelib.config.YamlUtil;
 import cn.drcomo.corelib.async.AsyncTaskManager;
 import cn.drcomo.corelib.hook.placeholder.PlaceholderAPIUtil;
 import cn.drcomo.corelib.math.FormulaCalculator;
+import cn.drcomo.util.ValueLimiter;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.ConfigurationSection;
@@ -318,6 +319,16 @@ public class RefactoredVariablesManager {
                 if (newValue == null) {
                     return VariableResult.failure("加法操作失败或超出约束", "ADD", key, playerName);
                 }
+                // 二次校验，若不合法则尝试按限制截断
+                if (!validateValue(variable, newValue)) {
+                    String adjusted = ValueLimiter.apply(variable, newValue);
+                    if (adjusted == null || !validateValue(variable, adjusted)) {
+                        return VariableResult.failure("加法结果超出限制", "ADD", key, playerName);
+                    }
+                    newValue = adjusted;
+                    finalDisplayValue = newValue;
+                }
+
                 updateMemoryAndInvalidate(player, variable, newValue);
                 logger.debug("加法操作: " + key + " = " + finalDisplayValue + " (当前: " + currentValue + " + 增加: " + addValue + ")");
                 return VariableResult.success(finalDisplayValue, "ADD", key, playerName);
@@ -364,6 +375,16 @@ public class RefactoredVariablesManager {
                 if (newValue == null) {
                     return VariableResult.failure("删除操作失败", "REMOVE", key, playerName);
                 }
+                // 二次校验，若不合法则尝试按限制截断
+                if (!validateValue(variable, newValue)) {
+                    String adjusted = ValueLimiter.apply(variable, newValue);
+                    if (adjusted == null || !validateValue(variable, adjusted)) {
+                        return VariableResult.failure("删除结果超出限制", "REMOVE", key, playerName);
+                    }
+                    newValue = adjusted;
+                    finalDisplayValue = newValue;
+                }
+
                 updateMemoryAndInvalidate(player, variable, newValue);
                 logger.debug("删除操作: " + key + " = " + finalDisplayValue + " (删除: " + removeValue + ")");
                 return VariableResult.success(finalDisplayValue, "REMOVE", key, playerName);

--- a/src/main/java/cn/drcomo/util/ValueLimiter.java
+++ b/src/main/java/cn/drcomo/util/ValueLimiter.java
@@ -1,0 +1,100 @@
+package cn.drcomo.util;
+
+import cn.drcomo.model.structure.Limitations;
+import cn.drcomo.model.structure.ValueType;
+import cn.drcomo.model.structure.Variable;
+
+import java.util.Arrays;
+
+/**
+ * 值限制工具类
+ *
+ * <p>用于根据 {@link Limitations} 对计算后的结果进行二次校验，
+ * 若超出范围则尝试截断到合法边界。</p>
+ */
+public class ValueLimiter {
+
+    /**
+     * 根据限制条件调整值
+     *
+     * @param variable 变量定义
+     * @param value    待调整的值
+     * @return 调整后的值，若无法调整则返回 {@code null}
+     */
+    public static String apply(Variable variable, String value) {
+        if (variable == null || value == null) {
+            return null;
+        }
+        Limitations limitations = variable.getLimitations();
+        if (limitations == null) {
+            return null;
+        }
+        ValueType type = variable.getValueType();
+        if (type == null) {
+            type = ValueType.inferFromValue(value);
+        }
+        switch (type) {
+            case INT:
+            case DOUBLE:
+                return limitNumber(type, value, limitations);
+            case STRING:
+                return limitString(value, limitations);
+            case LIST:
+                return limitList(value, limitations);
+            default:
+                return null;
+        }
+    }
+
+    // 数值截断
+    private static String limitNumber(ValueType type, String value, Limitations lim) {
+        double num;
+        try {
+            num = Double.parseDouble(value);
+        } catch (Exception e) {
+            return null;
+        }
+        double min = lim.getMinValue() != null ? parseDouble(lim.getMinValue(), num) : num;
+        double max = lim.getMaxValue() != null ? parseDouble(lim.getMaxValue(), num) : num;
+        num = Math.max(min, Math.min(max, num));
+        if (type == ValueType.INT) {
+            return String.valueOf((int) num);
+        }
+        return String.valueOf(num);
+    }
+
+    // 字符串长度截断
+    private static String limitString(String value, Limitations lim) {
+        int minLen = lim.getMinLength() != null ? lim.getMinLength() : 0;
+        int maxLen = lim.getMaxLength() != null ? lim.getMaxLength() : Integer.MAX_VALUE;
+        if (value.length() < minLen) {
+            return null;
+        }
+        if (value.length() > maxLen) {
+            return value.substring(0, maxLen);
+        }
+        return value;
+    }
+
+    // 列表数量截断
+    private static String limitList(String value, Limitations lim) {
+        String[] items = value.split(",");
+        int minCount = lim.getMinLength() != null ? lim.getMinLength() : 0;
+        int maxCount = lim.getMaxLength() != null ? lim.getMaxLength() : Integer.MAX_VALUE;
+        if (items.length < minCount) {
+            return null;
+        }
+        if (items.length > maxCount) {
+            return String.join(",", Arrays.asList(items).subList(0, maxCount));
+        }
+        return value;
+    }
+
+    private static double parseDouble(String text, double def) {
+        try {
+            return Double.parseDouble(text);
+        } catch (Exception e) {
+            return def;
+        }
+    }
+}

--- a/src/test/java/cn/drcomo/util/ValueLimiterTest.java
+++ b/src/test/java/cn/drcomo/util/ValueLimiterTest.java
@@ -1,0 +1,45 @@
+package cn.drcomo.util;
+
+import cn.drcomo.model.structure.Limitations;
+import cn.drcomo.model.structure.Variable;
+import cn.drcomo.model.structure.ValueType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * ValueLimiter 工具类测试
+ */
+public class ValueLimiterTest {
+
+    @Test
+    public void testIntClamp() {
+        Limitations lim = new Limitations.Builder().minValue("0").maxValue("100").build();
+        Variable var = new Variable.Builder("test-int").valueType(ValueType.INT).initial("0").limitations(lim).build();
+        String result = ValueLimiter.apply(var, "150");
+        assertEquals("100", result);
+    }
+
+    @Test
+    public void testStringTruncate() {
+        Limitations lim = new Limitations.Builder().maxLength(5).build();
+        Variable var = new Variable.Builder("test-str").valueType(ValueType.STRING).initial("").limitations(lim).build();
+        String result = ValueLimiter.apply(var, "abcdef");
+        assertEquals("abcde", result);
+    }
+
+    @Test
+    public void testListTruncate() {
+        Limitations lim = new Limitations.Builder().maxLength(3).build();
+        Variable var = new Variable.Builder("test-list").valueType(ValueType.LIST).initial("").limitations(lim).build();
+        String result = ValueLimiter.apply(var, "a,b,c,d,e");
+        assertEquals("a,b,c", result);
+    }
+
+    @Test
+    public void testStringTooShort() {
+        Limitations lim = new Limitations.Builder().minLength(2).build();
+        Variable var = new Variable.Builder("test-short").valueType(ValueType.STRING).initial("").limitations(lim).build();
+        assertNull(ValueLimiter.apply(var, "a"));
+    }
+}


### PR DESCRIPTION
## Summary
- 在变量增减操作中加入二次校验，超出限制时按边界截断
- 新增 `ValueLimiter` 工具类，实现数值、字符串与列表的限制处理
- 引入 JUnit5 并补充 `ValueLimiter` 单元测试

## Testing
- `mvn -q test` *(失败：无法连接 Maven 仓库)*

------
https://chatgpt.com/codex/tasks/task_e_689482091468833096b9c450ef1c6942