### PR TITLE
feat: 完成变量内存与缓存清理

### DIFF
--- a/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
+++ b/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
@@ -516,6 +516,35 @@ public class RefactoredVariablesManager {
         }
     }
 
+    /**
+     * 从内存与多级缓存中删除变量
+     *
+     * @param key 变量键
+     */
+    public void removeVariableFromMemoryAndCache(String key) {
+        try {
+            Variable variable = getVariableDefinition(key);
+            if (variable == null) {
+                logger.warn("变量不存在: " + key);
+                return;
+            }
+
+            if (variable.isGlobal()) {
+                memoryStorage.removeServerVariable(key);
+                cacheManager.invalidateCache(null, key);
+            } else if (variable.isPlayerScoped()) {
+                for (OfflinePlayer p : Bukkit.getOnlinePlayers()) {
+                    memoryStorage.removePlayerVariable(p.getUniqueId(), key);
+                    cacheManager.invalidateCache(p, key);
+                }
+            }
+
+            logger.debug("已从内存与缓存删除变量: " + key);
+        } catch (Exception e) {
+            logger.error("删除变量缓存失败: " + key, e);
+        }
+    }
+
     // ======================== 私有辅助方法 ========================
 
     /** 获取玩家名，若为空则返回 "SERVER" */

--- a/src/main/java/cn/drcomo/tasks/VariableCycleTask.java
+++ b/src/main/java/cn/drcomo/tasks/VariableCycleTask.java
@@ -215,7 +215,7 @@ public class VariableCycleTask {
         private boolean resetSingleVariableSafe(Variable var, String key) {
             for (int i = 1; i <= 3; i++) {
                 if (deleteVariableFromDb(var.isGlobal(), key)) {
-                    variablesManager.invalidateAllCaches(key);
+                    variablesManager.removeVariableFromMemoryAndCache(key);
                     logger.debug("重置变量成功: " + key + " (尝试 " + i + "/3)");
                     return true;
                 }


### PR DESCRIPTION
## Summary
- 新增 `removeVariableFromMemoryAndCache` 方法，支持从内存及多级缓存删除变量
- 周期任务在重置变量后调用新方法，保持缓存一致

## Testing
- `mvn -q -e -DskipTests package` *(失败: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68949b371e0483308c7ed6dbab704b3b