### PR TITLE
优化全局变量占位符玩家获取逻辑

### DIFF
--- a/src/main/java/cn/drcomo/DrcomoVEX.java
+++ b/src/main/java/cn/drcomo/DrcomoVEX.java
@@ -216,7 +216,7 @@ public class DrcomoVEX extends JavaPlugin {
      */
     private void registerListeners() {
         Bukkit.getPluginManager().registerEvents(
-                new PlayerListener(this, logger, playerVariablesManager),
+                new PlayerListener(this, logger, playerVariablesManager, serverVariablesManager),
                 this
         );
     }

--- a/src/main/java/cn/drcomo/listeners/PlayerListener.java
+++ b/src/main/java/cn/drcomo/listeners/PlayerListener.java
@@ -2,6 +2,7 @@ package cn.drcomo.listeners;
 
 import cn.drcomo.DrcomoVEX;
 import cn.drcomo.managers.PlayerVariablesManager;
+import cn.drcomo.managers.ServerVariablesManager;
 import cn.drcomo.corelib.util.DebugUtil;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -21,15 +22,18 @@ public class PlayerListener implements Listener {
     private final DrcomoVEX plugin;
     private final DebugUtil logger;
     private final PlayerVariablesManager playerVariablesManager;
+    private final ServerVariablesManager serverVariablesManager;
     
     public PlayerListener(
             DrcomoVEX plugin,
             DebugUtil logger,
-            PlayerVariablesManager playerVariablesManager
+            PlayerVariablesManager playerVariablesManager,
+            ServerVariablesManager serverVariablesManager
     ) {
         this.plugin = plugin;
         this.logger = logger;
         this.playerVariablesManager = playerVariablesManager;
+        this.serverVariablesManager = serverVariablesManager;
     }
     
     /**
@@ -47,6 +51,7 @@ public class PlayerListener implements Listener {
                     });
             
             logger.debug("玩家 " + event.getPlayer().getName() + " 登入，变量数据预加载中");
+            serverVariablesManager.handlePlayerJoin(event.getPlayer());
             
         } catch (Exception e) {
             logger.error("处理玩家登入事件失败: " + event.getPlayer().getName(), e);
@@ -68,6 +73,7 @@ public class PlayerListener implements Listener {
                     });
             
             logger.debug("玩家 " + event.getPlayer().getName() + " 退出，变量数据持久化中");
+            serverVariablesManager.handlePlayerQuit(event.getPlayer());
             
         } catch (Exception e) {
             logger.error("处理玩家退出事件失败: " + event.getPlayer().getName(), e);

--- a/src/main/java/cn/drcomo/managers/ServerVariablesManager.java
+++ b/src/main/java/cn/drcomo/managers/ServerVariablesManager.java
@@ -9,8 +9,9 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -26,6 +27,11 @@ public class ServerVariablesManager {
     private final DebugUtil logger;
     private final RefactoredVariablesManager variablesManager;
     private final HikariConnection database;
+
+    /**
+     * 在线玩家缓存列表，用于快速获取随机玩家
+     */
+    private final List<Player> onlinePlayerCache = new CopyOnWriteArrayList<>();
     
     public ServerVariablesManager(
             DrcomoVEX plugin,
@@ -44,7 +50,26 @@ public class ServerVariablesManager {
      */
     public void initialize() {
         logger.info("正在初始化服务器变量管理器...");
+        onlinePlayerCache.addAll(Bukkit.getOnlinePlayers());
         logger.info("服务器变量管理器初始化完成！");
+    }
+
+    /**
+     * 玩家加入时更新在线玩家缓存
+     *
+     * @param player 加入的玩家
+     */
+    public void handlePlayerJoin(Player player) {
+        onlinePlayerCache.add(player);
+    }
+
+    /**
+     * 玩家退出时更新在线玩家缓存
+     *
+     * @param player 退出的玩家
+     */
+    public void handlePlayerQuit(Player player) {
+        onlinePlayerCache.remove(player);
     }
     
     /**
@@ -52,15 +77,13 @@ public class ServerVariablesManager {
      * 对于全局变量，如果需要占位符解析，使用随机在线玩家
      */
     private OfflinePlayer getPlayerForPlaceholders() {
-        Collection<? extends Player> onlinePlayers = Bukkit.getOnlinePlayers();
-        if (onlinePlayers.isEmpty()) {
+        if (onlinePlayerCache.isEmpty()) {
             logger.debug("没有在线玩家可用于全局变量占位符解析");
             return null;
         }
-        
-        // 随机选择一个在线玩家用于占位符解析
-        Player[] players = onlinePlayers.toArray(new Player[0]);
-        Player randomPlayer = players[ThreadLocalRandom.current().nextInt(players.length)];
+
+        int randomIndex = ThreadLocalRandom.current().nextInt(onlinePlayerCache.size());
+        Player randomPlayer = onlinePlayerCache.get(randomIndex);
         logger.debug("选择玩家用于全局变量占位符解析: " + randomPlayer.getName());
         return randomPlayer;
     }


### PR DESCRIPTION
## 摘要
- 使用线程安全的在线玩家缓存，避免频繁数组转换
- 玩家进出事件实时维护缓存，提高全局变量占位符解析效率

## 测试
- `mvn -q -e -DskipTests package`（因网络不可用导致依赖解析失败）

------
https://chatgpt.com/codex/tasks/task_e_6894b8b597688330a2d84c2253aefefd