### PR TITLE
优化表达式判定逻辑

### DIFF
--- a/src/main/java/cn/drcomo/storage/MultiLevelCacheManager.java
+++ b/src/main/java/cn/drcomo/storage/MultiLevelCacheManager.java
@@ -13,7 +13,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 
 /**
  * 多级缓存管理器
@@ -43,6 +42,8 @@ public class MultiLevelCacheManager {
     // 表达式模式匹配器
     private final Pattern variablePattern = Pattern.compile("\\$\\{([^}]+)\\}");
     private final Pattern placeholderPattern = Pattern.compile("%([^%]+)%");
+    // 解析算术表达式所需的数字与运算符模式
+    private static final Pattern EXPRESSION_PATTERN = Pattern.compile("(?=.*\\d)(?=.*[+\\-*/()^])");
     
     // 缓存统计
     private final AtomicLong l1Hits = new AtomicLong(0);
@@ -270,8 +271,8 @@ public class MultiLevelCacheManager {
      */
     private boolean containsExpressions(String value) {
         if (value == null) return false;
-        return value.contains("%") || value.contains("${") || 
-               value.matches(".*[+\\-*/()^].*") && value.matches(".*\\d.*");
+        return value.contains("%") || value.contains("${") ||
+               EXPRESSION_PATTERN.matcher(value).find();
     }
     
     /**


### PR DESCRIPTION
## 摘要
- 预编译算术表达式模式，避免重复创建正则
- 使用 matcher.find() 取代 String.matches，提高性能并保持原有行为

## 测试
- `mvn -q -e test`（依赖下载失败，网络不可达）

------
https://chatgpt.com/codex/tasks/task_e_6894b8954810833083d32dd44a4f5bf9