### PR TITLE
feat: 统一数据库异步线程池

### DIFF
--- a/src/main/java/cn/drcomo/DrcomoVEX.java
+++ b/src/main/java/cn/drcomo/DrcomoVEX.java
@@ -159,7 +159,7 @@ public class DrcomoVEX extends JavaPlugin {
      * 初始化数据库连接
      */
     private void initializeDatabase() {
-        database = new HikariConnection(this, logger, configsManager);
+        database = new HikariConnection(this, logger, configsManager, asyncTaskManager);
         database.initialize();
     }
     


### PR DESCRIPTION
## Summary
- 引入 `AsyncTaskManager` 并通过构造函数注入到 `HikariConnection`
- 使用 `asyncTaskManager` 替换原有 `CompletableFuture.supplyAsync/runAsync`
- `DrcomoVEX` 构建 `HikariConnection` 时注入统一线程池

## Testing
- `mvn test` *(失败：Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6894b85b82b0833097f429e6c136cde7