### PR TITLE
重构变量作用域校验逻辑

### DIFF
--- a/src/main/java/cn/drcomo/managers/PlayerVariablesManager.java
+++ b/src/main/java/cn/drcomo/managers/PlayerVariablesManager.java
@@ -2,6 +2,7 @@ package cn.drcomo.managers;
 
 import cn.drcomo.DrcomoVEX;
 import cn.drcomo.model.VariableResult;
+import cn.drcomo.model.structure.ScopeType;
 import cn.drcomo.model.structure.Variable;
 import cn.drcomo.database.HikariConnection;
 import cn.drcomo.corelib.util.DebugUtil;
@@ -9,6 +10,7 @@ import org.bukkit.OfflinePlayer;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 
 /**
  * 玩家变量管理器
@@ -68,19 +70,10 @@ public class PlayerVariablesManager {
      * 设置玩家变量值
      */
     public CompletableFuture<VariableResult> setPlayerVariable(OfflinePlayer player, String key, String value) {
-        Variable variable = variablesManager.getVariableDefinition(key);
-        if (variable == null) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不存在: " + key)
-            );
+        Optional<VariableResult> validation = variablesManager.validateScope(key, ScopeType.PLAYER);
+        if (validation.isPresent()) {
+            return CompletableFuture.completedFuture(validation.get());
         }
-        
-        if (!variable.isPlayerScoped()) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不是玩家作用域: " + key)
-            );
-        }
-        
         return withTimeout(variablesManager.setVariable(player, key, value));
     }
     
@@ -89,23 +82,11 @@ public class PlayerVariablesManager {
      */
     public CompletableFuture<VariableResult> addPlayerVariable(OfflinePlayer player, String key, String addValue) {
         logger.debug("玩家变量管理器：开始添加变量 " + key + " 对玩家 " + player.getName() + "，值：" + addValue);
-        
-        Variable variable = variablesManager.getVariableDefinition(key);
-        if (variable == null) {
-            logger.debug("变量定义不存在: " + key);
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不存在: " + key)
-            );
+        Optional<VariableResult> validation = variablesManager.validateScope(key, ScopeType.PLAYER);
+        if (validation.isPresent()) {
+            logger.debug("变量校验失败: " + validation.get().getErrorMessage());
+            return CompletableFuture.completedFuture(validation.get());
         }
-        
-        if (!variable.isPlayerScoped()) {
-            logger.debug("变量不是玩家作用域: " + key + ", 实际作用域: " + (variable.isPlayerScoped() ? "player" : "server"));
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不是玩家作用域: " + key)
-            );
-        }
-        
-        logger.debug("变量校验通过，委托给 RefactoredVariablesManager");
         return withTimeout(variablesManager.addVariable(player, key, addValue));
     }
     
@@ -113,19 +94,10 @@ public class PlayerVariablesManager {
      * 移除玩家变量值
      */
     public CompletableFuture<VariableResult> removePlayerVariable(OfflinePlayer player, String key, String removeValue) {
-        Variable variable = variablesManager.getVariableDefinition(key);
-        if (variable == null) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不存在: " + key)
-            );
+        Optional<VariableResult> validation = variablesManager.validateScope(key, ScopeType.PLAYER);
+        if (validation.isPresent()) {
+            return CompletableFuture.completedFuture(validation.get());
         }
-        
-        if (!variable.isPlayerScoped()) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不是玩家作用域: " + key)
-            );
-        }
-        
         return withTimeout(variablesManager.removeVariable(player, key, removeValue));
     }
     
@@ -133,19 +105,10 @@ public class PlayerVariablesManager {
      * 重置玩家变量
      */
     public CompletableFuture<VariableResult> resetPlayerVariable(OfflinePlayer player, String key) {
-        Variable variable = variablesManager.getVariableDefinition(key);
-        if (variable == null) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不存在: " + key)
-            );
+        Optional<VariableResult> validation = variablesManager.validateScope(key, ScopeType.PLAYER);
+        if (validation.isPresent()) {
+            return CompletableFuture.completedFuture(validation.get());
         }
-        
-        if (!variable.isPlayerScoped()) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不是玩家作用域: " + key)
-            );
-        }
-        
         return withTimeout(variablesManager.resetVariable(player, key));
     }
     

--- a/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
+++ b/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
@@ -3,6 +3,7 @@ package cn.drcomo.managers;
 import cn.drcomo.DrcomoVEX;
 import cn.drcomo.model.VariableResult;
 import cn.drcomo.model.structure.Variable;
+import cn.drcomo.model.structure.ScopeType;
 import cn.drcomo.model.structure.Limitations;
 import cn.drcomo.model.structure.ValueType;
 import cn.drcomo.storage.VariableMemoryStorage;
@@ -478,6 +479,27 @@ public class RefactoredVariablesManager {
                 .filter(e -> e.getValue().isGlobal())
                 .map(Map.Entry::getKey)
                 .collect(Collectors.toSet());
+    }
+
+    /**
+     * 验证变量作用域是否符合预期
+     *
+     * @param key       变量键
+     * @param scopeType 期望的作用域类型
+     * @return 若验证失败返回错误结果，否则返回 {@code Optional.empty()}
+     */
+    public Optional<VariableResult> validateScope(String key, ScopeType scopeType) {
+        Variable variable = getVariableDefinition(key);
+        if (variable == null) {
+            return Optional.of(VariableResult.failure("变量不存在: " + key));
+        }
+        if (scopeType == ScopeType.PLAYER && !variable.isPlayerScoped()) {
+            return Optional.of(VariableResult.failure("变量不是玩家作用域: " + key));
+        }
+        if (scopeType == ScopeType.GLOBAL && !variable.isGlobal()) {
+            return Optional.of(VariableResult.failure("变量不是全局作用域: " + key));
+        }
+        return Optional.empty();
     }
 
     /**

--- a/src/main/java/cn/drcomo/managers/ServerVariablesManager.java
+++ b/src/main/java/cn/drcomo/managers/ServerVariablesManager.java
@@ -2,6 +2,7 @@ package cn.drcomo.managers;
 
 import cn.drcomo.DrcomoVEX;
 import cn.drcomo.model.VariableResult;
+import cn.drcomo.model.structure.ScopeType;
 import cn.drcomo.model.structure.Variable;
 import cn.drcomo.database.HikariConnection;
 import cn.drcomo.corelib.util.DebugUtil;
@@ -12,6 +13,7 @@ import org.bukkit.entity.Player;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.Optional;
 
 /**
  * 服务器变量管理器
@@ -87,19 +89,10 @@ public class ServerVariablesManager {
      * 设置服务器变量值
      */
     public CompletableFuture<VariableResult> setServerVariable(String key, String value) {
-        Variable variable = variablesManager.getVariableDefinition(key);
-        if (variable == null) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不存在: " + key)
-            );
+        Optional<VariableResult> validation = variablesManager.validateScope(key, ScopeType.GLOBAL);
+        if (validation.isPresent()) {
+            return CompletableFuture.completedFuture(validation.get());
         }
-        
-        if (!variable.isGlobal()) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不是全局作用域: " + key)
-            );
-        }
-        
         OfflinePlayer playerForPlaceholders = getPlayerForPlaceholders();
         return variablesManager.setVariable(playerForPlaceholders, key, value);
     }
@@ -108,19 +101,10 @@ public class ServerVariablesManager {
      * 增加服务器变量值
      */
     public CompletableFuture<VariableResult> addServerVariable(String key, String addValue) {
-        Variable variable = variablesManager.getVariableDefinition(key);
-        if (variable == null) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不存在: " + key)
-            );
+        Optional<VariableResult> validation = variablesManager.validateScope(key, ScopeType.GLOBAL);
+        if (validation.isPresent()) {
+            return CompletableFuture.completedFuture(validation.get());
         }
-        
-        if (!variable.isGlobal()) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不是全局作用域: " + key)
-            );
-        }
-        
         OfflinePlayer playerForPlaceholders = getPlayerForPlaceholders();
         return variablesManager.addVariable(playerForPlaceholders, key, addValue);
     }
@@ -129,19 +113,10 @@ public class ServerVariablesManager {
      * 移除服务器变量值
      */
     public CompletableFuture<VariableResult> removeServerVariable(String key, String removeValue) {
-        Variable variable = variablesManager.getVariableDefinition(key);
-        if (variable == null) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不存在: " + key)
-            );
+        Optional<VariableResult> validation = variablesManager.validateScope(key, ScopeType.GLOBAL);
+        if (validation.isPresent()) {
+            return CompletableFuture.completedFuture(validation.get());
         }
-        
-        if (!variable.isGlobal()) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不是全局作用域: " + key)
-            );
-        }
-        
         OfflinePlayer playerForPlaceholders = getPlayerForPlaceholders();
         return variablesManager.removeVariable(playerForPlaceholders, key, removeValue);
     }
@@ -150,19 +125,10 @@ public class ServerVariablesManager {
      * 重置服务器变量
      */
     public CompletableFuture<VariableResult> resetServerVariable(String key) {
-        Variable variable = variablesManager.getVariableDefinition(key);
-        if (variable == null) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不存在: " + key)
-            );
+        Optional<VariableResult> validation = variablesManager.validateScope(key, ScopeType.GLOBAL);
+        if (validation.isPresent()) {
+            return CompletableFuture.completedFuture(validation.get());
         }
-        
-        if (!variable.isGlobal()) {
-            return CompletableFuture.completedFuture(
-                    VariableResult.failure("变量不是全局作用域: " + key)
-            );
-        }
-        
         OfflinePlayer playerForPlaceholders = getPlayerForPlaceholders();
         return variablesManager.resetVariable(playerForPlaceholders, key);
     }

--- a/src/main/java/cn/drcomo/model/structure/ScopeType.java
+++ b/src/main/java/cn/drcomo/model/structure/ScopeType.java
@@ -1,0 +1,13 @@
+package cn.drcomo.model.structure;
+
+/**
+ * 变量作用域类型枚举
+ * <p>
+ * 用于区分变量是玩家作用域还是全局作用域。
+ */
+public enum ScopeType {
+    /** 玩家作用域变量 */
+    PLAYER,
+    /** 全局作用域变量 */
+    GLOBAL
+}


### PR DESCRIPTION
## 概要
- 抽取 `validateScope` 方法统一处理变量作用域校验
- 玩家与服务器变量管理器重用校验逻辑并删除重复分支
- 新增 `ScopeType` 枚举描述玩家/全局作用域

## 测试
- `mvn -q -e test`（网络不可达，依赖下载失败）

------
https://chatgpt.com/codex/tasks/task_e_6894b8c55c988330b0cc56c96bd1ee5f