### PR TITLE
预编译占位符解析正则模式

### DIFF
--- a/src/main/java/cn/drcomo/api/ServerVariablesAPI.java
+++ b/src/main/java/cn/drcomo/api/ServerVariablesAPI.java
@@ -36,6 +36,9 @@ import java.util.regex.Pattern;
  */
 public class ServerVariablesAPI {
 
+    /** 占位符完整格式校验正则 */
+    private static final Pattern FULL_PLACEHOLDER_PATTERN = Pattern.compile("^drcomovex_\\[([^]]+)]_(.+)$");
+
     private final DebugUtil logger;
     private final RefactoredVariablesManager variablesManager;
     private final ServerVariablesManager serverVariablesManager;
@@ -189,7 +192,7 @@ public class ServerVariablesAPI {
         }
 
         String full = "drcomovex_" + placeholder + "_" + rawArgs;
-        Matcher m = Pattern.compile("^drcomovex_\\[([^]]+)]_(.+)$").matcher(full);
+        Matcher m = FULL_PLACEHOLDER_PATTERN.matcher(full);
         if (!m.matches()) {
             String result = "错误";
             logger.error("占位符 " + full + " 参数解析失败");


### PR DESCRIPTION
## 摘要
- 新增 `FULL_PLACEHOLDER_PATTERN` 常量，统一占位符解析正则
- 使用预编译正则替代 `processPlaceholder` 方法内临时编译

## 测试
- `mvn -q -e test` (依赖下载失败，提示 Network is unreachable)

------
https://chatgpt.com/codex/tasks/task_e_6894d2a9ea808330b759a1d4bfde6485