### PR TITLE
优化玩家变量删除与索引维护逻辑

### DIFF
--- a/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
+++ b/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
@@ -707,9 +708,10 @@ public class RefactoredVariablesManager {
                 memoryStorage.removeServerVariable(key);
                 cacheManager.invalidateCache(null, key);
             } else if (variable.isPlayerScoped()) {
-                for (OfflinePlayer p : Bukkit.getOnlinePlayers()) {
-                    memoryStorage.removePlayerVariable(p.getUniqueId(), key);
-                    cacheManager.invalidateCache(p, key);
+                Set<UUID> affectedPlayers = memoryStorage.removeVariableForAllPlayers(key, true);
+                for (UUID affected : affectedPlayers) {
+                    OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(affected);
+                    cacheManager.invalidateCache(offlinePlayer, key);
                 }
             }
             logger.debug("已从内存与缓存删除变量: " + key);
@@ -1493,6 +1495,10 @@ public class RefactoredVariablesManager {
                                 : tri.value;
                             memoryStorage.loadPlayerVariable(
                                     player.getUniqueId(), key, normalizedValue, tri.updatedAt, tri.firstModifiedAt);
+                        } else {
+                            if (memoryStorage.removePlayerVariable(player.getUniqueId(), key, false)) {
+                                cacheManager.invalidateCache(player, key);
+                            }
                         }
                     }).exceptionally(ex -> {
                         logger.error("加载玩家变量失败: " + pid + " - " + key, ex);

--- a/src/main/java/cn/drcomo/storage/BatchPersistenceManager.java
+++ b/src/main/java/cn/drcomo/storage/BatchPersistenceManager.java
@@ -190,12 +190,16 @@ public class BatchPersistenceManager {
         return CompletableFuture.runAsync(() -> {
             try {
                 Map<String, DirtyFlag> dirty = memoryStorage.getPlayerDirtyData(playerId);
-                if (dirty.isEmpty()) return;
-                logger.debug("玩家退出，立即持久化数据: " + playerId + "，脏数据数量: " + dirty.size());
-                List<PersistenceTask> tasks = collectPersistenceTasks(dirty);
-                executeBatchPersistence(tasks);
+                if (!dirty.isEmpty()) {
+                    logger.debug("玩家退出，立即持久化数据: " + playerId + "，脏数据数量: " + dirty.size());
+                    List<PersistenceTask> tasks = collectPersistenceTasks(dirty);
+                    executeBatchPersistence(tasks);
+                    logger.debug("玩家数据持久化完成: " + playerId);
+                } else {
+                    logger.debug("玩家退出，无脏数据需要持久化: " + playerId);
+                }
                 memoryStorage.cleanupPlayerData(playerId, false);
-                logger.debug("玩家数据持久化完成: " + playerId);
+                logger.debug("玩家内存镜像已释放: " + playerId);
             } catch (Exception e) {
                 logger.error("持久化玩家数据失败: " + playerId, e);
                 failedPersistenceOperations.incrementAndGet();


### PR DESCRIPTION
## 概要
- 扩展内存存储的玩家变量删除接口，支持批量清理并同步刷新脏标记与首次修改索引
- 调整变量管理器在内存与缓存清理时使用新的批量删除能力，确保缓存失效覆盖离线玩家
- 更新玩家离线持久化流程，使其在无脏数据时也释放内存镜像并清理相关索引

## 测试
- `mvn -q -DskipTests package` *(失败：403 无法拉取 maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e5dea99cdc83308d07748848ec3fb8