### PR TITLE
feat: 支持全局变量无 server-id 的数据库拉取同步

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# DrcomoVEX
+
+## 插件介绍
+
+DrcomoVEX 是一个面向 Paper/Spigot 服务器的变量管理插件，支持玩家变量、全局变量、表达式计算、周期重置、渐进恢复、条件门控与 PlaceholderAPI 集成。
+
+## 优势
+
+- 支持 `player` 与 `global` 两种作用域
+- 支持数学表达式、变量引用与 PlaceholderAPI 占位符
+- 支持 `daily`、`weekly`、`monthly`、Cron 等周期重置
+- 支持 `regen` 渐进恢复规则
+- 支持 Redis 跨服同步
+- 支持无 `server-id` 的全局变量数据库拉取同步
+- 支持 MySQL 事件表跨服同步兼容模式
+
+## 使用方法
+
+1. 将插件放入 `plugins` 目录，并确保服务端已安装 `DrcomoCoreLib`
+2. 按需安装 `PlaceholderAPI`、`Vault`、`PlayerPoints`
+3. 在 `config.yml` 中配置数据库
+4. 在 `variables/*.yml` 中定义变量
+5. 重启服务器或执行 `/vex reload`
+
+### MySQL 跨服同步配置
+
+如果主人使用的是多子服共用一个 MySQL，而没有启用 Redis，请在 `config.yml` 中开启：
+
+```yml
+settings:
+  cross-server-sync:
+    enabled: true
+    server-id: "survival-1"
+```
+
+注意：
+
+- `database.type` 必须为 `mysql`
+- 每个子服都必须配置不同的 `server-id`
+- 如果已经启用 `settings.redis-sync.enabled: true`，则优先使用 Redis，同步链路不会走 MySQL 事件表
+
+### 全局变量无 server-id 同步
+
+如果主人只关心 `scope=global` 的变量跨服一致性，现在插件会默认开启数据库拉取同步：
+
+```yml
+settings:
+  global-db-sync:
+    enabled: true
+    poll-interval-millis: 1000
+```
+
+说明：
+
+- 这套同步不需要配置 `settings.cross-server-sync.server-id`
+- 只处理 `global` 变量
+- 需要多子服共用同一个 MySQL
+- 玩家变量跨服逻辑保持原样，不受这套同步影响
+
+## 命令
+
+- `/vex help` 查看帮助
+- `/vex reload` 重载插件
+- `/vex player get <玩家> <变量>`
+- `/vex player set <玩家> <变量> <值>`
+- `/vex player add <玩家> <变量> <值>`
+- `/vex player remove <玩家> <变量> <值>`
+- `/vex player reset <玩家> <变量>`
+- `/vex global get <变量>`
+- `/vex global set <变量> <值>`
+- `/vex global add <变量> <值>`
+- `/vex global remove <变量> <值>`
+- `/vex global reset <变量>`
+
+## 权限
+
+- `drcomovex.command.*` 指令权限总节点
+- `drcomovex.command.help` 查看帮助
+- `drcomovex.command.get`
+- `drcomovex.command.set`
+- `drcomovex.command.add`
+- `drcomovex.command.remove`
+- `drcomovex.command.reset`
+- `drcomovex.admin.*` 管理权限总节点
+- `drcomovex.admin.reload` 重载插件
+
+## 更新说明
+
+### 1.2.0
+
+- 新增仅针对 `global` 变量的数据库拉取同步
+- 新增全局变量写穿数据库逻辑，减少跨服可见延迟
+- 这套全局同步不再依赖 `settings.cross-server-sync.server-id`
+- 保持玩家变量跨服逻辑不变
+- 将插件版本提升到 `1.2.0`
+
+### 1.1.0
+
+- 修复了仅配置数据库时，全局变量不会自动跨服同步的问题
+- 新增 MySQL 事件表跨服同步所需的默认配置项
+- 新增 `player_variable_change_events` 与 `player_variable_change_consumers` 表结构
+- 在变量写入、删除、重置时补充事件表写入逻辑
+- 将插件版本提升到 `1.1.0`

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>cn.drcomo</groupId>
     <artifactId>DrcomoVEX</artifactId>
-    <version>1.0.0</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>DrcomoVEX</name>

--- a/src/main/java/cn/drcomo/DrcomoVEX.java
+++ b/src/main/java/cn/drcomo/DrcomoVEX.java
@@ -5,6 +5,7 @@ import cn.drcomo.managers.*;
 import cn.drcomo.listeners.PlayerListener;
 import cn.drcomo.api.ServerVariablesAPI;
 import cn.drcomo.tasks.DataSaveTask;
+import cn.drcomo.tasks.GlobalVariableSyncTask;
 import cn.drcomo.tasks.VariableCycleTask;
 import cn.drcomo.database.HikariConnection;
 import cn.drcomo.corelib.util.DebugUtil;
@@ -30,7 +31,7 @@ import org.bukkit.Bukkit;
  * 动态表达式计算、周期性重置和全能指令操作。
  * 
  * @author BaiMo
- * @version 1.0.0
+ * @version 1.2.0
  */
 public class DrcomoVEX extends JavaPlugin {
     
@@ -60,6 +61,7 @@ public class DrcomoVEX extends JavaPlugin {
     private DataSaveTask dataSaveTask;
     private VariableCycleTask variableCycleTask;
     private cn.drcomo.tasks.VariableRegenTask variableRegenTask;
+    private GlobalVariableSyncTask globalVariableSyncTask;
 
     // Redis 跨服同步（可选）
     private RedisConnection redisConnection;
@@ -104,6 +106,9 @@ public class DrcomoVEX extends JavaPlugin {
 
         // 7.6 启动 MySQL 轮询跨服同步（仅在 Redis 不可用或未启用时）
         startMySQLCrossServerSyncIfNeeded();
+
+        // 7.7 启动全局变量数据库拉取同步（无需 server-id）
+        startGlobalDatabaseSyncIfNeeded();
         
         // 8. 注册API接口
         registerAPI();
@@ -117,7 +122,7 @@ public class DrcomoVEX extends JavaPlugin {
         }
 
         logger.info("DrcomoVEX 变量扩展系统已成功启动！");
-        logger.info("版本: 1.0.0 (代号: 直觉)");
+        logger.info("版本: 1.2.0 (代号: 直觉)");
         logger.info("感谢使用 DrcomoVEX - 让变量管理变得直观而强大！");
     }
     
@@ -134,6 +139,9 @@ public class DrcomoVEX extends JavaPlugin {
         }
         if (variableRegenTask != null) {
             variableRegenTask.stop();
+        }
+        if (globalVariableSyncTask != null) {
+            globalVariableSyncTask.stop();
         }
 
         // 1.5 停止 Redis 同步
@@ -449,6 +457,21 @@ public class DrcomoVEX extends JavaPlugin {
             }
         } catch (Exception e) {
             logger.warn("停止 MySQL 轮询跨服同步失败: " + e.getMessage());
+        }
+    }
+
+    private void startGlobalDatabaseSyncIfNeeded() {
+        try {
+            globalVariableSyncTask = new GlobalVariableSyncTask(
+                    this,
+                    logger,
+                    variablesManager,
+                    database,
+                    configsManager.getMainConfig()
+            );
+            globalVariableSyncTask.start();
+        } catch (Exception e) {
+            logger.error("启动全局变量数据库拉取同步失败", e);
         }
     }
 

--- a/src/main/java/cn/drcomo/config/MainConfigManager.java
+++ b/src/main/java/cn/drcomo/config/MainConfigManager.java
@@ -102,6 +102,23 @@ public class MainConfigManager {
         yamlUtil.getBoolean(CONFIG_FILE, "settings.check-updates", true);
         yamlUtil.getBoolean(CONFIG_FILE, "settings.notify-ops", true);
 
+        // 全局变量数据库拉取同步（无需 server-id）
+        yamlUtil.getBoolean(CONFIG_FILE, "settings.global-db-sync.enabled", true);
+        yamlUtil.getInt(CONFIG_FILE, "settings.global-db-sync.poll-interval-millis", 1000);
+        yamlUtil.getLong(CONFIG_FILE, "settings.global-db-sync.query-timeout-millis", 5000L);
+
+        // MySQL 事件表跨服同步（旧兼容方案）
+        yamlUtil.getBoolean(CONFIG_FILE, "settings.cross-server-sync.enabled", false);
+        yamlUtil.getString(CONFIG_FILE, "settings.cross-server-sync.server-id", "");
+        yamlUtil.getInt(CONFIG_FILE, "settings.cross-server-sync.poll-interval-ms", 250);
+        yamlUtil.getInt(CONFIG_FILE, "settings.cross-server-sync.batch-size", 500);
+        yamlUtil.getInt(CONFIG_FILE, "settings.cross-server-sync.retention-days", 7);
+        yamlUtil.getBoolean(CONFIG_FILE, "settings.cross-server-sync.fail-closed-on-db-error", true);
+        yamlUtil.getInt(CONFIG_FILE, "settings.cross-server-sync.cleanup-interval-seconds", 180);
+        yamlUtil.getInt(CONFIG_FILE, "settings.cross-server-sync.cleanup-safety-margin", 1000);
+        yamlUtil.getBoolean(CONFIG_FILE, "settings.cross-server-sync.ignore-stale-consumers", false);
+        yamlUtil.getInt(CONFIG_FILE, "settings.cross-server-sync.consumer-stale-days", 7);
+
         // Redis 跨服同步配置（可选）
         yamlUtil.getBoolean(CONFIG_FILE, "settings.redis-sync.enabled", false);
         yamlUtil.getString(CONFIG_FILE, "settings.redis-sync.host", "127.0.0.1");

--- a/src/main/java/cn/drcomo/config/MainConfigSchema.java
+++ b/src/main/java/cn/drcomo/config/MainConfigSchema.java
@@ -50,6 +50,27 @@ public class MainConfigSchema implements ConfigSchema {
 				.custom(n -> ((Number) n).intValue() >= 1, "cycle.check-interval-seconds 不能小于 1");
 		validator.validateString("cycle.timezone");
 
+		// 全局变量数据库拉取同步配置
+		validator.validateNumber("settings.global-db-sync.poll-interval-millis")
+				.custom(n -> ((Number) n).intValue() >= 250, "settings.global-db-sync.poll-interval-millis 不能小于 250");
+		validator.validateNumber("settings.global-db-sync.query-timeout-millis")
+				.custom(n -> ((Number) n).longValue() >= 1000L, "settings.global-db-sync.query-timeout-millis 不能小于 1000");
+
+		// MySQL 事件表跨服同步配置
+		validator.validateString("settings.cross-server-sync.server-id");
+		validator.validateNumber("settings.cross-server-sync.poll-interval-ms")
+				.custom(n -> ((Number) n).intValue() >= 100, "settings.cross-server-sync.poll-interval-ms 不能小于 100");
+		validator.validateNumber("settings.cross-server-sync.batch-size")
+				.custom(n -> ((Number) n).intValue() >= 50, "settings.cross-server-sync.batch-size 不能小于 50");
+		validator.validateNumber("settings.cross-server-sync.retention-days")
+				.custom(n -> ((Number) n).intValue() >= 1, "settings.cross-server-sync.retention-days 不能小于 1");
+		validator.validateNumber("settings.cross-server-sync.cleanup-interval-seconds")
+				.custom(n -> ((Number) n).intValue() >= 60, "settings.cross-server-sync.cleanup-interval-seconds 不能小于 60");
+		validator.validateNumber("settings.cross-server-sync.cleanup-safety-margin")
+				.custom(n -> ((Number) n).intValue() >= 100, "settings.cross-server-sync.cleanup-safety-margin 不能小于 100");
+		validator.validateNumber("settings.cross-server-sync.consumer-stale-days")
+				.custom(n -> ((Number) n).intValue() >= 1, "settings.cross-server-sync.consumer-stale-days 不能小于 1");
+
 		// 日志级别
 		validator.validateString("debug.level")
 				.custom(v -> {

--- a/src/main/java/cn/drcomo/database/HikariConnection.java
+++ b/src/main/java/cn/drcomo/database/HikariConnection.java
@@ -459,6 +459,46 @@ public class HikariConnection {
     }
 
     /**
+     * 异步查询全部服务器全局变量。
+     * 返回列顺序: [variable_key, value, updated_at, first_modified_at]
+     */
+    public CompletableFuture<List<String[]>> queryAllServerVariablesAsync() {
+        String sql = "SELECT variable_key, value, updated_at, first_modified_at FROM server_variables";
+
+        if ("sqlite".equals(databaseType)) {
+            return sqliteDB.queryListAsync(sql, rs -> new String[] {
+                    rs.getString(1),
+                    rs.getString(2),
+                    rs.getString(3),
+                    rs.getString(4)
+            });
+        }
+
+        return CompletableFuture.supplyAsync(() -> {
+            List<String[]> results = new ArrayList<>();
+            try (Connection conn = getConnection();
+                 PreparedStatement stmt = conn.prepareStatement(sql)) {
+                try { conn.setNetworkTimeout(dbExecutor, 15000); } catch (Throwable ignore) {}
+                try { stmt.setQueryTimeout(15); } catch (Throwable ignore) {}
+                try (ResultSet rs = stmt.executeQuery()) {
+                    while (rs.next()) {
+                        results.add(new String[] {
+                                rs.getString(1),
+                                rs.getString(2),
+                                rs.getString(3),
+                                rs.getString(4)
+                        });
+                    }
+                }
+            } catch (SQLException e) {
+                logger.error("查询全部服务器变量失败", e);
+                throw new RuntimeException("查询全部服务器变量失败", e);
+            }
+            return results;
+        }, dbExecutor);
+    }
+
+    /**
      * 异步执行更新
      */
     public CompletableFuture<Integer> executeUpdateAsync(String sql, Object... params) {

--- a/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
+++ b/src/main/java/cn/drcomo/managers/RefactoredVariablesManager.java
@@ -31,6 +31,7 @@ import cn.drcomo.redis.RedisCrossServerSync;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
+import org.bukkit.configuration.file.FileConfiguration;
  
 
 
@@ -130,6 +131,7 @@ public class RefactoredVariablesManager {
 
     // 初始化完成状态
     private final AtomicBoolean initialized = new AtomicBoolean(false);
+    private final AtomicBoolean warnedMissingLegacySyncServerId = new AtomicBoolean(false);
 
     // 验证过程中传递当前变量键的线程本地变量
     private final ThreadLocal<String> currentValidatingVariable = new ThreadLocal<>();
@@ -1788,6 +1790,14 @@ public class RefactoredVariablesManager {
 
             // 触发玩家变量变更事件（异步）
             firePlayerVariableChangeEvent(player, variable.getKey(), oldValue, value, reason);
+            emitLegacyCrossServerChangeEvent(
+                    variable,
+                    player,
+                    broadcastValue,
+                    broadcastUpdatedAt,
+                    broadcastFirstModifiedAt,
+                    reason != null ? reason.name() : "OTHER"
+            );
 
             // Redis 跨服广播（仅广播，不做本地回写）
             if (latest != null && redisSyncService != null && redisSyncService.isEnabled()) {
@@ -1817,10 +1827,20 @@ public class RefactoredVariablesManager {
             if (!persist) {
                 memoryStorage.clearDirtyFlag("server:" + variable.getKey());
                 logger.debug("服务器变量设置为不可持久化，跳过数据库保存: " + variable.getKey());
+            } else if (latest != null) {
+                writeThroughGlobalVariable(variable.getKey(), latest);
             }
             // 全局上下文缓存一并清理
             invalidateCachesSafely(null, variable.getKey());
             // 注意：全局变量暂不触发事件，因为 PlayerVariableChangeEvent 需要 player
+            emitLegacyCrossServerChangeEvent(
+                    variable,
+                    null,
+                    broadcastValue,
+                    broadcastUpdatedAt,
+                    broadcastFirstModifiedAt,
+                    reason != null ? reason.name() : "OTHER"
+            );
 
             // Redis 广播全局变量变更
             if (latest != null && redisSyncService != null && redisSyncService.isEnabled()) {
@@ -1949,6 +1969,7 @@ public class RefactoredVariablesManager {
             VariableValue before = memoryStorage.getPlayerVariable(player.getUniqueId(), variable.getKey());
             long first = before != null ? before.getFirstModifiedAt() : now;
             memoryStorage.removePlayerVariable(player.getUniqueId(), variable.getKey());
+            emitLegacyCrossServerChangeEvent(variable, player, null, now, first, op);
             if (redisSyncService != null && redisSyncService.isEnabled()) {
                 asyncTaskManager.getExecutor().execute(() -> {
                     try {
@@ -1969,6 +1990,8 @@ public class RefactoredVariablesManager {
             VariableValue before = memoryStorage.getServerVariable(variable.getKey());
             long first = before != null ? before.getFirstModifiedAt() : now;
             memoryStorage.removeServerVariable(variable.getKey());
+            writeThroughDeleteGlobalVariable(variable.getKey());
+            emitLegacyCrossServerChangeEvent(variable, null, null, now, first, op);
             if (redisSyncService != null && redisSyncService.isEnabled()) {
                 asyncTaskManager.getExecutor().execute(() -> {
                     try {
@@ -1990,6 +2013,143 @@ public class RefactoredVariablesManager {
     /** 缓存失效的安全封装（缓存层已移除，此方法为空操作） */
     private void invalidateCachesSafely(OfflinePlayer player, String key) {
         // 缓存层已移除，此方法保留仅为代码兼容
+    }
+
+    /**
+     * 全局变量写穿数据库。
+     * 这样其他子服通过数据库拉取同步时，可以尽快看到最新值，而不必等待批量持久化周期。
+     */
+    private void writeThroughGlobalVariable(String key, VariableValue latest) {
+        if (key == null || latest == null || !isGlobalDbSyncEnabled()) {
+            return;
+        }
+
+        database.executeUpdateAsync(
+                "INSERT INTO server_variables " +
+                        "(variable_key, value, created_at, updated_at, first_modified_at) VALUES (?, ?, ?, ?, ?) " +
+                        "ON DUPLICATE KEY UPDATE value = VALUES(value), updated_at = VALUES(updated_at), first_modified_at = VALUES(first_modified_at)",
+                key,
+                latest.getRawValue(),
+                latest.getCreatedAt(),
+                latest.getLastModified(),
+                latest.getFirstModifiedAt()
+        ).exceptionally(ex -> {
+            logger.warn("全局变量写穿数据库失败: key=" + key
+                    + ", err=" + (ex != null ? ex.getMessage() : "unknown"));
+            return 0;
+        });
+    }
+
+    /**
+     * 全局变量删除时同步删除数据库记录。
+     */
+    private void writeThroughDeleteGlobalVariable(String key) {
+        if (key == null || key.isEmpty() || !isGlobalDbSyncEnabled()) {
+            return;
+        }
+
+        database.executeUpdateAsync(
+                "DELETE FROM server_variables WHERE variable_key = ?",
+                key
+        ).exceptionally(ex -> {
+            logger.warn("删除全局变量数据库记录失败: key=" + key
+                    + ", err=" + (ex != null ? ex.getMessage() : "unknown"));
+            return 0;
+        });
+    }
+
+    /**
+     * 是否启用“全局变量数据库拉取同步”。
+     */
+    private boolean isGlobalDbSyncEnabled() {
+        if (database == null || !database.isMySQL()) {
+            return false;
+        }
+        try {
+            FileConfiguration config = configsManager != null ? configsManager.getMainConfig() : null;
+            return config != null && config.getBoolean("settings.global-db-sync.enabled", true);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * 向旧版 MySQL 事件表写入跨服同步事件。
+     * 仅当启用了 settings.cross-server-sync 且当前未启用 Redis 同步时生效。
+     */
+    private void emitLegacyCrossServerChangeEvent(
+            Variable variable,
+            OfflinePlayer player,
+            String rawValue,
+            long updatedAt,
+            long firstModifiedAt,
+            String op
+    ) {
+        if (variable == null || !isLegacyMySqlSyncEventEnabled()) {
+            return;
+        }
+
+        String serverId = getLegacyMySqlSyncServerId();
+        if (serverId.isEmpty()) {
+            if (warnedMissingLegacySyncServerId.compareAndSet(false, true)) {
+                logger.warn("已启用 MySQL 跨服同步，但未配置 settings.cross-server-sync.server-id，事件将不会写入。");
+            }
+            return;
+        }
+
+        String scope = variable.isGlobal() ? "GLOBAL" : "PLAYER";
+        String playerUuid = null;
+        if (variable.isPlayerScoped() && player != null && player.getUniqueId() != null) {
+            playerUuid = player.getUniqueId().toString();
+        }
+
+        database.executeUpdateAsync(
+                "INSERT INTO player_variable_change_events " +
+                        "(server_id, player_uuid, variable_key, value, updated_at, first_modified_at, scope, op, created_at) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                serverId,
+                playerUuid,
+                variable.getKey(),
+                rawValue,
+                updatedAt,
+                firstModifiedAt,
+                scope,
+                op != null ? op : "OTHER",
+                System.currentTimeMillis()
+        ).exceptionally(ex -> {
+            logger.warn("写入 MySQL 跨服同步事件失败: key=" + variable.getKey()
+                    + ", scope=" + scope
+                    + ", err=" + (ex != null ? ex.getMessage() : "unknown"));
+            return 0;
+        });
+    }
+
+    private boolean isLegacyMySqlSyncEventEnabled() {
+        if (redisSyncService != null && redisSyncService.isEnabled()) {
+            return false;
+        }
+        if (database == null || !database.isMySQL()) {
+            return false;
+        }
+        try {
+            FileConfiguration config = configsManager != null ? configsManager.getMainConfig() : null;
+            return config != null && config.getBoolean("settings.cross-server-sync.enabled", false);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private String getLegacyMySqlSyncServerId() {
+        try {
+            FileConfiguration config = configsManager != null ? configsManager.getMainConfig() : null;
+            if (config == null) {
+                return "";
+            }
+            String serverId = config.getString("settings.cross-server-sync.server-id", "");
+            return serverId != null ? serverId.trim() : "";
+        } catch (Exception e) {
+            return "";
+        }
     }
 
     /** 统一出口：在返回前应用渐进恢复 */

--- a/src/main/java/cn/drcomo/tasks/GlobalVariableSyncTask.java
+++ b/src/main/java/cn/drcomo/tasks/GlobalVariableSyncTask.java
@@ -1,0 +1,235 @@
+package cn.drcomo.tasks;
+
+import cn.drcomo.DrcomoVEX;
+import cn.drcomo.corelib.util.DebugUtil;
+import cn.drcomo.database.HikariConnection;
+import cn.drcomo.managers.RefactoredVariablesManager;
+import cn.drcomo.storage.VariableValue;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 全局变量数据库拉取同步任务。
+ *
+ * 设计目标：
+ * 1. 仅处理 scope=global 的变量
+ * 2. 通过共享 MySQL 的 server_variables 表实现跨服同步
+ * 3. 不依赖 settings.cross-server-sync.server-id
+ * 4. 维持“玩家变量跨服逻辑不动”
+ */
+public class GlobalVariableSyncTask {
+
+    private final DrcomoVEX plugin;
+    private final DebugUtil logger;
+    private final RefactoredVariablesManager variablesManager;
+    private final HikariConnection database;
+    private final FileConfiguration config;
+
+    /**
+     * 记录最近一次从数据库确认过的更新时间。
+     * 仅用于安全判断“该变量是否确实已在数据库中被删除”。
+     */
+    private final ConcurrentHashMap<String, Long> lastSeenDbUpdatedAt = new ConcurrentHashMap<>();
+    private final AtomicBoolean polling = new AtomicBoolean(false);
+    private volatile boolean waitForInitializationLogged;
+    private ScheduledFuture<?> task;
+
+    public GlobalVariableSyncTask(
+            DrcomoVEX plugin,
+            DebugUtil logger,
+            RefactoredVariablesManager variablesManager,
+            HikariConnection database,
+            FileConfiguration config
+    ) {
+        this.plugin = plugin;
+        this.logger = logger;
+        this.variablesManager = variablesManager;
+        this.database = database;
+        this.config = config;
+    }
+
+    public void start() {
+        if (!isEnabled()) {
+            logger.info("全局变量数据库拉取同步已禁用");
+            return;
+        }
+        if (database == null || !database.isMySQL()) {
+            logger.info("全局变量数据库拉取同步仅支持共享 MySQL，当前已跳过");
+            return;
+        }
+        if (plugin.getRedisCrossServerSync() != null && plugin.getRedisCrossServerSync().isEnabled()) {
+            logger.info("Redis 同步已启用，跳过全局变量数据库拉取同步");
+            return;
+        }
+
+        int intervalMillis = Math.max(250, config.getInt("settings.global-db-sync.poll-interval-millis", 1000));
+        task = plugin.getAsyncTaskManager().scheduleAtFixedRate(
+                this::poll,
+                intervalMillis,
+                intervalMillis,
+                TimeUnit.MILLISECONDS
+        );
+        logger.info("已启动全局变量数据库拉取同步，间隔: " + intervalMillis + " 毫秒");
+    }
+
+    public void stop() {
+        if (task != null && !task.isCancelled()) {
+            task.cancel(false);
+            logger.info("全局变量数据库拉取同步已停止");
+        }
+    }
+
+    private void poll() {
+        if (!polling.compareAndSet(false, true)) {
+            return;
+        }
+
+        try {
+            if (!variablesManager.isInitialized()) {
+                if (!waitForInitializationLogged) {
+                    waitForInitializationLogged = true;
+                    logger.info("变量管理器尚未初始化完成，暂缓全局变量数据库拉取同步");
+                }
+                return;
+            }
+
+            if (waitForInitializationLogged) {
+                waitForInitializationLogged = false;
+                logger.info("变量管理器初始化完成，开始执行全局变量数据库拉取同步");
+            }
+
+            Map<String, DbGlobalRecord> dbMap = fetchDatabaseGlobals();
+            if (dbMap == null) {
+                return;
+            }
+
+            applyDatabaseRows(dbMap);
+            applyDeletions(dbMap.keySet());
+        } finally {
+            polling.set(false);
+        }
+    }
+
+    private Map<String, DbGlobalRecord> fetchDatabaseGlobals() {
+        try {
+            long timeoutMillis = Math.max(1000L, config.getLong("settings.global-db-sync.query-timeout-millis", 5000L));
+            List<String[]> rows = database.queryAllServerVariablesAsync()
+                    .orTimeout(timeoutMillis, TimeUnit.MILLISECONDS)
+                    .get(timeoutMillis, TimeUnit.MILLISECONDS);
+
+            Map<String, DbGlobalRecord> dbMap = new HashMap<>();
+            for (String[] row : rows) {
+                if (row == null || row.length < 4) {
+                    continue;
+                }
+                String key = row[0];
+                if (key == null || key.isEmpty()) {
+                    continue;
+                }
+                dbMap.put(key, new DbGlobalRecord(
+                        key,
+                        row[1],
+                        parseLongOrZero(row[2]),
+                        parseLongOrZero(row[3])
+                ));
+            }
+            return dbMap;
+        } catch (TimeoutException e) {
+            logger.warn("全局变量数据库拉取同步超时");
+        } catch (Exception e) {
+            logger.warn("全局变量数据库拉取同步失败: " + e.getMessage());
+        }
+        return null;
+    }
+
+    private void applyDatabaseRows(Map<String, DbGlobalRecord> dbMap) {
+        Set<String> globalKeys = variablesManager.getGlobalVariableKeys();
+        for (Map.Entry<String, DbGlobalRecord> entry : dbMap.entrySet()) {
+            String key = entry.getKey();
+            if (!globalKeys.contains(key)) {
+                continue;
+            }
+
+            DbGlobalRecord record = entry.getValue();
+            lastSeenDbUpdatedAt.put(key, record.updatedAt);
+            variablesManager.applyRemoteGlobalChange(
+                    key,
+                    record.value,
+                    record.updatedAt,
+                    record.firstModifiedAt
+            );
+        }
+    }
+
+    private void applyDeletions(Set<String> existingDbKeys) {
+        for (String key : variablesManager.getGlobalVariableKeys()) {
+            if (existingDbKeys.contains(key)) {
+                continue;
+            }
+
+            Long lastSeen = lastSeenDbUpdatedAt.get(key);
+            if (lastSeen == null) {
+                continue;
+            }
+
+            VariableValue current = variablesManager.getMemoryStorage().getServerVariable(key);
+            if (current == null) {
+                lastSeenDbUpdatedAt.remove(key);
+                continue;
+            }
+            if (shouldApplyDelete(current, lastSeen)) {
+                variablesManager.applyRemoteGlobalDelete(key, lastSeen);
+                lastSeenDbUpdatedAt.remove(key);
+            }
+        }
+    }
+
+    /**
+     * 仅当本服仍停留在“上次已确认的数据库版本”或更旧版本时，才允许按数据库缺失判定为删除。
+     * 这样可以避免覆盖本服尚未完成写库的新值。
+     */
+    static boolean shouldApplyDelete(VariableValue current, Long lastSeenDbUpdatedAt) {
+        if (current == null || lastSeenDbUpdatedAt == null) {
+            return false;
+        }
+        if (current.isDirty()) {
+            return false;
+        }
+        return current.getLastModified() <= lastSeenDbUpdatedAt;
+    }
+
+    private boolean isEnabled() {
+        return config.getBoolean("settings.global-db-sync.enabled", true);
+    }
+
+    private long parseLongOrZero(String input) {
+        try {
+            return input == null ? 0L : Long.parseLong(input.trim());
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
+
+    private static final class DbGlobalRecord {
+        private final String key;
+        private final String value;
+        private final long updatedAt;
+        private final long firstModifiedAt;
+
+        private DbGlobalRecord(String key, String value, long updatedAt, long firstModifiedAt) {
+            this.key = key;
+            this.value = value;
+            this.updatedAt = updatedAt;
+            this.firstModifiedAt = firstModifiedAt;
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 # ================================================================
 # DrcomoVEX - 基于直觉设计的服务器变量管理系统
-# 版本: 1.0.0 (代号: 直觉)
+# 版本: 1.2.0 (代号: 直觉)
 # 作者: BaiMo
 # ================================================================
 
@@ -73,6 +73,31 @@ settings:
 
   # 是否通知 OP 更新
   notify-ops: true
+
+  # 全局变量数据库拉取同步
+  # - 只处理 scope=global 的变量
+  # - 基于共享 MySQL 的 server_variables 表，无需 server-id
+  # - Redis 已启用时会自动跳过，因为 Redis 已负责实时同步
+  global-db-sync:
+    enabled: true
+    poll-interval-millis: 1000
+    query-timeout-millis: 5000
+
+  # MySQL 事件表跨服同步（旧兼容方案）
+  # - 仅在 database.type=mysql 时生效
+  # - 仅在 Redis 同步未启用或不可用时启用
+  # - 每个子服必须配置唯一 server-id，否则不会启动
+  cross-server-sync:
+    enabled: false
+    server-id: ""                # 必填：每个子服唯一标识，例如 survival-1 / survival-2
+    poll-interval-ms: 250        # 轮询事件表间隔（毫秒）
+    batch-size: 500              # 每轮最多拉取的事件数量
+    retention-days: 7            # 事件保留天数
+    fail-closed-on-db-error: true
+    cleanup-interval-seconds: 180
+    cleanup-safety-margin: 1000
+    ignore-stale-consumers: false
+    consumer-stale-days: 7
 
   # Redis 跨服同步（多子服共库场景）
   redis-sync:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: DrcomoVEX
-version: 1.0.0
+version: 1.2.0
 main: cn.drcomo.DrcomoVEX
 api-version: 1.16
 author: BaiMo

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,6 +18,28 @@ CREATE TABLE IF NOT EXISTS server_variables (
     first_modified_at BIGINT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS player_variable_change_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    server_id VARCHAR(64) NOT NULL,
+    player_uuid VARCHAR(36),
+    variable_key VARCHAR(255) NOT NULL,
+    value TEXT,
+    updated_at BIGINT NOT NULL,
+    first_modified_at BIGINT NOT NULL,
+    scope VARCHAR(16) NOT NULL,
+    op VARCHAR(32) NOT NULL,
+    created_at BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS player_variable_change_consumers (
+    server_id VARCHAR(64) NOT NULL PRIMARY KEY,
+    last_event_id BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_player_variables_uuid ON player_variables(player_uuid);
 CREATE INDEX IF NOT EXISTS idx_player_variables_key ON player_variables(variable_key);
 CREATE INDEX IF NOT EXISTS idx_server_variables_key ON server_variables(variable_key);
+CREATE INDEX IF NOT EXISTS idx_change_events_server ON player_variable_change_events(server_id);
+CREATE INDEX IF NOT EXISTS idx_change_events_created ON player_variable_change_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_change_events_scope_key ON player_variable_change_events(scope, variable_key);

--- a/src/test/java/cn/drcomo/tasks/GlobalVariableSyncTaskTest.java
+++ b/src/test/java/cn/drcomo/tasks/GlobalVariableSyncTaskTest.java
@@ -1,0 +1,36 @@
+package cn.drcomo.tasks;
+
+import cn.drcomo.storage.VariableValue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 针对全局变量数据库拉取同步中的删除保护逻辑进行测试。
+ */
+public class GlobalVariableSyncTaskTest {
+
+    @Test
+    void shouldApplyDelete_whenCurrentOlderAndClean_returnsTrue() {
+        VariableValue value = new VariableValue("100", 100L, 100L);
+
+        assertTrue(GlobalVariableSyncTask.shouldApplyDelete(value, 100L));
+        assertTrue(GlobalVariableSyncTask.shouldApplyDelete(value, 101L));
+    }
+
+    @Test
+    void shouldApplyDelete_whenCurrentDirty_returnsFalse() {
+        VariableValue value = new VariableValue("100", 100L, 100L);
+        value.markDirty();
+
+        assertFalse(GlobalVariableSyncTask.shouldApplyDelete(value, 100L));
+    }
+
+    @Test
+    void shouldApplyDelete_whenNoLastSeenTimestamp_returnsFalse() {
+        VariableValue value = new VariableValue("100", 100L, 100L);
+
+        assertFalse(GlobalVariableSyncTask.shouldApplyDelete(value, null));
+    }
+}


### PR DESCRIPTION
## 变更说明
- 为 `scope=global` 增加基于共享 MySQL `server_variables` 的数据库拉取同步，不再依赖 `settings.cross-server-sync.server-id`
- 保留现有玩家变量跨服逻辑不变，避免影响 Redis / 旧事件表同步链路
- 全局变量写入与删除时增加直写数据库，减少各子服读到旧缓存的窗口
- 新增 `settings.global-db-sync` 配置项、默认值与校验
- 增加对应测试，并将插件版本更新到 `1.2.0`
